### PR TITLE
Bypass cache if Authorization header is present

### DIFF
--- a/common-caching.js
+++ b/common-caching.js
@@ -61,6 +61,9 @@ function requestIsCachable(request) {
   if (hasPrivateCookie(request)) {
     return false;
   }
+  if (hasAuthorizationHeader(request)) {
+    return false;
+  }
   return true;
 }
 
@@ -73,6 +76,10 @@ function hasPrivateCookie(request) {
       return cookieString.includes(item);
     })
   );
+}
+
+function hasAuthorizationHeader(request) {
+  return request.headers.has("Authorization");
 }
 
 function responseIsCachable(response) {


### PR DESCRIPTION
Not tested.

- This will bypass cache on requests that come from a user with basic auth.
- This won't bypass IP allowing - I have plans for this tm-kn/django-basic-auth-ip-whitelist#8