### PR TITLE
Use cookie parser to read cookies for matching

### DIFF
--- a/common-caching.js
+++ b/common-caching.js
@@ -65,8 +65,9 @@ function requestIsCachable(request) {
 }
 
 function hasPrivateCookie(request) {
+  const requestCookieNames = request.headers.get("Cookie").split(";").map(cookie => cookie.split("=")[0].trim());
   // Check if the request includes any of the specified 'private' cookies
-  return PRIVATE_COOKIES.some((private_cookie_name) => getCookie(request, private_cookie_name) != "");
+  return PRIVATE_COOKIES.some((privateCookieName) => requestCookieNames.includes(privateCookieName));
 }
 
 function responseIsCachable(response) {
@@ -74,27 +75,4 @@ function responseIsCachable(response) {
     return false;
   }
   return true;
-}
-
-/**
- * Source: https://developers.cloudflare.com/workers/examples/extract-cookie-value
- * Gets the cookie with the name from the request headers
- * @param {Request} request incoming Request
- * @param {string} name of the cookie to get
- */
- function getCookie(request, name) {
-  let result = ""
-  const cookieString = request.headers.get("Cookie")
-  if (cookieString) {
-    const cookies = cookieString.split(";")
-    cookies.forEach(cookie => {
-      const cookiePair = cookie.split("=", 2)
-      const cookieName = cookiePair[0].trim()
-      if (cookieName === name) {
-        const cookieVal = cookiePair[1]
-        result = cookieVal
-      }
-    })
-  }
-  return result
 }

--- a/common-caching.js
+++ b/common-caching.js
@@ -66,13 +66,7 @@ function requestIsCachable(request) {
 
 function hasPrivateCookie(request) {
   // Check if the request includes any of the specified 'private' cookies
-  const cookieString = request.headers.get("Cookie");
-  return (
-    cookieString !== null &&
-    PRIVATE_COOKIES.some((item) => {
-      return cookieString.includes(item);
-    })
-  );
+  return PRIVATE_COOKIES.some((private_cookie_name) => getCookie(request, private_cookie_name) != "");
 }
 
 function responseIsCachable(response) {
@@ -80,4 +74,27 @@ function responseIsCachable(response) {
     return false;
   }
   return true;
+}
+
+/**
+ * Source: https://developers.cloudflare.com/workers/examples/extract-cookie-value
+ * Gets the cookie with the name from the request headers
+ * @param {Request} request incoming Request
+ * @param {string} name of the cookie to get
+ */
+ function getCookie(request, name) {
+  let result = ""
+  const cookieString = request.headers.get("Cookie")
+  if (cookieString) {
+    const cookies = cookieString.split(";")
+    cookies.forEach(cookie => {
+      const cookiePair = cookie.split("=", 2)
+      const cookieName = cookiePair[0].trim()
+      if (cookieName === name) {
+        const cookieVal = cookiePair[1]
+        result = cookieVal
+      }
+    })
+  }
+  return result
 }


### PR DESCRIPTION
Previously this would match cookies whose values _contained_ the private cookies, rather than simply checking for their existence.

Implementation copied from https://developers.cloudflare.com/workers/examples/extract-cookie-value