### PR TITLE
Allow including cookies and headers in cache key

### DIFF
--- a/common-caching.js
+++ b/common-caching.js
@@ -8,9 +8,21 @@ const PRIVATE_COOKIES = ["sessionid"];
 // Cookies to include in the cache key
 const VARY_COOKIES = [];
 
-// Headers to include in the cache key.
+// Request headers to include in the cache key.
 // Note: Do not add `cookie` to this list!
-const VARY_HEADERS = [];
+const VARY_HEADERS = [
+    "X-Requested-With",
+
+    // HTMX
+    "HX-Boosted",
+    "HX-Current-URL",
+    "HX-History-Restore-Request",
+    "HX-Prompt",
+    "HX-Request",
+    "HX-Target",
+    "HX-Trigger-Name",
+    "HX-Trigger",
+];
 
 // These querystring keys are stripped from the request as they are generally not
 // needed by the origin.


### PR DESCRIPTION
It's a feature we end up wanting regularly: "Cache based on the value of this cookie". So, might as well make it configuration rather than a code change.

Since I was there, I also added the same functionality for headers, although that's likely less useful for us. It's not quite as intelligent as the `Vary` header (which Cloudflare ignores anyway), but it's something.