### PR TITLE
Add theme_mode to VARY_COOKIES

### DIFF
--- a/common-caching.js
+++ b/common-caching.js
@@ -6,7 +6,9 @@
 const PRIVATE_COOKIES = ["sessionid"];
 
 // Cookies to include in the cache key
-const VARY_COOKIES = [];
+const VARY_COOKIES = [
+  "theme_mode"
+];
 
 // Request headers to include in the cache key.
 // Note: Do not add `cookie` to this list!


### PR DESCRIPTION
This MR adds `theme_mode` to `VARY_COOKIES` to help handle Charity Kit dark mode switching.

Ticket: https://linear.app/torchbox/issue/PDB-93/add-theme-mod-to-cloudflare-cache